### PR TITLE
fix: default toggling and double click on column to reset the width

### DIFF
--- a/docs/examples/TogglingExample.tsx
+++ b/docs/examples/TogglingExample.tsx
@@ -8,7 +8,7 @@ export default function TogglingExample() {
   const { effectiveColumns, resetColumnsToggle } = useDataTableColumns({
     key,
     columns: [
-      { accessor: 'name', width: '40%', toggleable: true },
+      { accessor: 'name', width: '40%', toggleable: true, defaultToggle: false },
       { accessor: 'streetAddress', width: '60%', toggleable: true },
       { accessor: 'city', width: 160, toggleable: true },
       { accessor: 'state' },

--- a/docs/pages/examples/dragging-toggling.tsx
+++ b/docs/pages/examples/dragging-toggling.tsx
@@ -53,6 +53,12 @@ export default function Page({ code }: InferGetStaticPropsType<typeof getStaticP
 
       <PageSubtitle value="Toggling" />
 
+      <PageText>
+        In the below example you can toggle the first 3 columns. The last column is not toggleable and will always be
+        visible. The first column is toggled off by default. Click with right mouse button on the header to select the
+        columns you want to toggle.
+      </PageText>
+
       <TogglingExample />
 
       <PageText>
@@ -71,6 +77,11 @@ export default function Page({ code }: InferGetStaticPropsType<typeof getStaticP
       </PageText>
 
       <CodeBlock language="typescript" content={code['toggling']} />
+
+      <PageText info>
+        You may define which columns will be toggled by default by setting the <Code>defaultToggle: false</Code>{' '}
+        property
+      </PageText>
 
       <PageSubtitle value="Dragging & Toggling with context menu Reset" />
       <DraggingTogglingResetExample />

--- a/package/DataTableResizableHeaderHandle.tsx
+++ b/package/DataTableResizableHeaderHandle.tsx
@@ -85,7 +85,7 @@ export const DataTableResizableHeaderHandle = (props: DataTableResizableHeaderHa
 
     setColumnWidth(accessor, columnRef.current.style.width as string);
 
-    columnRef.current.style.width = '';
+    columnRef.current.style.width = 'initial';
 
     setDeltaX(0);
   };

--- a/package/hooks.ts
+++ b/package/hooks.ts
@@ -154,7 +154,7 @@ export const useDataTableColumns = <T>({
     getInitialValueInEffect: true,
   });
 
-  // Store the columns with in localStorage
+  // Store the columns width in localStorage
   const [columnsWidth, setColumnsWidth] = useLocalStorage<DataTableColumnWidth[]>({
     key: `${key}-columns-width`,
     defaultValue: defaultColumnsWidth as DataTableColumnWidth[],
@@ -187,7 +187,7 @@ export const useDataTableColumns = <T>({
         };
       }) as DataTableColumn<T>[];
 
-    const newWith = result.map((column) => {
+    const newWidths = result.map((column) => {
       return {
         ...column,
         width: columnsWidth.find((width) => {
@@ -196,7 +196,7 @@ export const useDataTableColumns = <T>({
       };
     });
 
-    return newWith;
+    return newWidths;
   }, [columns, columnsOrder, columnsToggle, columnsWidth]);
 
   const setColumnWidth = (accessor: string, width: string | number) => {

--- a/package/hooks.ts
+++ b/package/hooks.ts
@@ -128,7 +128,7 @@ export const useDataTableColumns = <T>({
 
   // create an array of object with key = accessor and value = width
   const defaultColumnsWidth =
-    (columns && columns.map((column) => ({ [column.accessor]: column.width ?? 'auto' }))) || [];
+    (columns && columns.map((column) => ({ [column.accessor]: column.width ?? 'initial' }))) || [];
 
   // Default columns id toggled is the array of columns which have the toggleable property set to true
   const defaultColumnsToggle =
@@ -137,7 +137,7 @@ export const useDataTableColumns = <T>({
       accessor: column.accessor,
       defaultToggle: column.defaultToggle || true,
       toggleable: column.toggleable,
-      toggled: column.defaultToggle || true,
+      toggled: column.defaultToggle === undefined ? true : column.defaultToggle,
     }));
 
   // Store the columns order in localStorage
@@ -165,7 +165,9 @@ export const useDataTableColumns = <T>({
   // we got issue with rendering
   const resetColumnsOrder = () => setColumnsOrder(defaultColumnsOrder as string[]);
 
-  const resetColumnsToggle = () => setColumnsToggle(defaultColumnsToggle as DataTableColumnToggle[]);
+  const resetColumnsToggle = () => {
+    setColumnsToggle(defaultColumnsToggle as DataTableColumnToggle[]);
+  };
 
   const resetColumnsWidth = () => setColumnsWidth(defaultColumnsWidth as DataTableColumnWidth[]);
 
@@ -176,11 +178,14 @@ export const useDataTableColumns = <T>({
 
     const result = columnsOrder
       .map((order) => columns.find((column) => column.accessor === order))
-      .filter((column) => {
-        return columnsToggle.find((toggle) => {
-          return toggle.accessor === column?.accessor;
-        })?.toggled;
-      });
+      .map((column) => {
+        return {
+          ...column,
+          hidden: !columnsToggle.find((toggle) => {
+            return toggle.accessor === column?.accessor;
+          })?.toggled,
+        };
+      }) as DataTableColumn<T>[];
 
     const newWith = result.map((column) => {
       return {


### PR DESCRIPTION
- Fixed the `defaultToggle` attribute that was not working
- Fixed the issue with the Double Click that was preventing the column from being resized
- Updated the docs/example