### PR TITLE
fix: unnecessary title map that caused an exception

### DIFF
--- a/docs/examples/TogglingExample.tsx
+++ b/docs/examples/TogglingExample.tsx
@@ -1,4 +1,5 @@
 import { Button, Group, Stack } from '@mantine/core';
+import { IconMap } from '@tabler/icons-react';
 import { DataTable, useDataTableColumns } from 'mantine-datatable';
 import { companies } from '~/data';
 
@@ -11,7 +12,11 @@ export default function TogglingExample() {
       { accessor: 'name', width: '40%', toggleable: true, defaultToggle: false },
       { accessor: 'streetAddress', width: '60%', toggleable: true },
       { accessor: 'city', width: 160, toggleable: true },
-      { accessor: 'state' },
+      {
+        accessor: 'state',
+        width: 40,
+        title: <IconMap />,
+      },
     ],
   });
 

--- a/package/hooks.ts
+++ b/package/hooks.ts
@@ -109,7 +109,6 @@ export function useElementOuterSize<T extends HTMLElement>() {
 
 export type DataTableColumnToggle = {
   accessor: string;
-  title: string | undefined;
   defaultToggle: boolean;
   toggleable: boolean;
   toggled: boolean;
@@ -137,7 +136,6 @@ export const useDataTableColumns = <T>({
     columns.map((column) => ({
       accessor: column.accessor,
       defaultToggle: column.defaultToggle || true,
-      title: column.title,
       toggleable: column.toggleable,
       toggled: column.defaultToggle === undefined ? true : column.defaultToggle,
     }));


### PR DESCRIPTION
Fix the below issue

`Unhandled Runtime Error
Error: @mantine/hooks use-local-storage: Failed to serialize the value`

When the `title` in the columns array is not just a simple `string`

<img width="1011" alt="image" src="https://github.com/icflorescu/mantine-datatable-v6/assets/432181/46392bfc-6c2e-4f3f-9cb5-39a990b8330e">
